### PR TITLE
put original id stx in log message rather than datum

### DIFF
--- a/mutate-lib/private/mutator-lib.rkt
+++ b/mutate-lib/private/mutator-lib.rkt
@@ -170,7 +170,7 @@
                                  swapped
                                  maybe-atom-stx
                                  maybe-atom-stx))
-                (apply-swap-alist (syntax->datum maybe-atom-stx)
+                (apply-swap-alist maybe-atom-stx
                                   swaps
                                   mutation-index
                                   counter))))))
@@ -181,7 +181,7 @@
                           counter)
   (define mutator-sequence
     (for/list ([{orig new} (in-dict swap-alist)])
-      (make-guarded-mutator (λ (v) (equal? v orig))
+      (make-guarded-mutator (λ (v) (equal? (syntax->datum v) orig))
                             (λ (v) new))))
   (apply-mutators original-value
                   mutator-sequence


### PR DESCRIPTION
This change puts the original syntax object into the log message rather than the corresponding datum, which allows the receiver of the log message to see what source location was mutated.

It's possible that if this change makes sense, there are a bunch of other changes that would follow, for things other than ids; let me know if that's the case, I'd be happy to broaden the net a bit. Also, maybe I should include tests?

Basically, let me know if you think this is a reasonable direction to go in.